### PR TITLE
Fix the regular expression to adapt to the case where the node name contains -

### DIFF
--- a/pkg/slurm/topology/tree/eval_nodes_tree_test.go
+++ b/pkg/slurm/topology/tree/eval_nodes_tree_test.go
@@ -64,7 +64,7 @@ func Test_eval_nodes_tree_topo1(t *testing.T) {
 	err := switch_record_validate("../../../../test/topology1.conf")
 	require.NoError(t, err)
 
-	node_map := &bitstr_t{"tux1", "tux3", "tux5", "tux6", "tux7"}
+	node_map := &bitstr_t{"tu-x1", "tu-x3", "tux5", "tux6", "tux7"}
 	eval := &topology_eval_t{
 		node_map:  node_map,
 		req_nodes: 3,
@@ -74,7 +74,7 @@ func Test_eval_nodes_tree_topo1(t *testing.T) {
 	require.Equal(t, &bitstr_t{"tux5", "tux6", "tux7"}, eval.node_map)
 	require.Equal(t, uint16(2), eval.leaf_switch_cnt)
 
-	node_map = &bitstr_t{"tux1"}
+	node_map = &bitstr_t{"tu-x1"}
 	eval = &topology_eval_t{
 		node_map:  node_map,
 		req_nodes: 3,
@@ -82,29 +82,29 @@ func Test_eval_nodes_tree_topo1(t *testing.T) {
 	rc = eval_nodes_tree(eval, false)
 	require.Equal(t, slurm.ERROR, rc)
 
-	node_map = &bitstr_t{"tux0", "tux2", "tux4", "tux7"}
+	node_map = &bitstr_t{"tu-x0", "tu-x2", "tux4", "tux7"}
 	eval = &topology_eval_t{
 		node_map:  node_map,
 		req_nodes: 3,
 	}
 	rc = eval_nodes_tree(eval, false)
 	require.Equal(t, slurm.SUCCESS, rc)
-	require.Equal(t, &bitstr_t{"tux0", "tux2", "tux4"}, eval.node_map)
+	require.Equal(t, &bitstr_t{"tu-x0", "tu-x2", "tux4"}, eval.node_map)
 	require.Equal(t, uint16(3), eval.leaf_switch_cnt)
 
 	// With req_node_bitmap
-	node_map = &bitstr_t{"tux0", "tux2", "tux4", "tux7"}
+	node_map = &bitstr_t{"tu-x0", "tu-x2", "tux4", "tux7"}
 	eval = &topology_eval_t{
 		node_map:        node_map,
-		req_node_bitmap: &bitstr_t{"tux0", "tux2", "tux4"},
+		req_node_bitmap: &bitstr_t{"tu-x0", "tu-x2", "tux4"},
 		req_nodes:       3,
 	}
 	rc = eval_nodes_tree(eval, false)
 	require.Equal(t, slurm.SUCCESS, rc)
-	require.Equal(t, &bitstr_t{"tux0", "tux2", "tux4"}, eval.node_map)
+	require.Equal(t, &bitstr_t{"tu-x0", "tu-x2", "tux4"}, eval.node_map)
 	require.Equal(t, uint16(3), eval.leaf_switch_cnt)
 
-	node_map = &bitstr_t{"tux0", "tux1", "tux2", "tux4", "tux5", "tux6"}
+	node_map = &bitstr_t{"tu-x0", "tu-x1", "tu-x2", "tux4", "tux5", "tux6"}
 	eval = &topology_eval_t{
 		node_map:        node_map,
 		req_node_bitmap: &bitstr_t{"tux4"},

--- a/pkg/slurm/topology/tree/switch_record.go
+++ b/pkg/slurm/topology/tree/switch_record.go
@@ -187,7 +187,7 @@ func _check_better_path(i, j, k int) {
 
 func _node_name2bitmap(node_names string) (*bitstr_t, error) {
 	// Regular expression to match patterns like "node[1-3,5,7-9]"
-	re := regexp.MustCompile(`([a-zA-Z]+)\[([0-9,-]+)\]`)
+	re := regexp.MustCompile(`([a-zA-Z-]+)\[([0-9,-]+)\]`)
 	matches := re.FindStringSubmatch(node_names)
 
 	if len(matches) != 3 {

--- a/test/topology1.conf
+++ b/test/topology1.conf
@@ -1,7 +1,7 @@
 # topology.conf
 # Switch Configuration
-SwitchName=s0 Nodes=tux[0-1]
-SwitchName=s1 Nodes=tux[2-3]
+SwitchName=s0 Nodes=tu-x[0-1]
+SwitchName=s1 Nodes=tu-x[2-3]
 SwitchName=s2 Nodes=tux[4-5]
 SwitchName=s3 Nodes=tux[6-7]
 SwitchName=s4 Switches=s[0-1]


### PR DESCRIPTION
Currently, when parsing node names, the node name containing `-` cannot be handled.
What's more coincidental is that when creating a multi-node cluster through kind, the name of the worker contains -, and kind does not support modifying the node name. This will cause some trouble for testing.

```
$ kubectl get node 
NAME                 STATUS   ROLES           AGE   VERSION
kind-control-plane   Ready    control-plane   53s   v1.31.0
kind-worker          Ready    <none>          43s   v1.31.0
kind-worker2         Ready    <none>          43s   v1.31.0
kind-worker3         Ready    <none>          42s   v1.31.0
kind-worker4         Ready    <none>          43s   v1.31.0
```