### PR TITLE
refactor switchRecordValidate, Now it receives topo directly.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,7 +23,11 @@ var (
 			log.Debugf("Required nodes: %#v", requiredNodes)
 			log.Debugf("Number of nodes requested: %d", requested)
 
-			err := tree.SwitchRecordValidate(topology)
+			ptr_array, err := tree.ReadTopoFile(topology)
+			if err != nil {
+				return err
+			}
+			err = tree.SwitchRecordValidate(ptr_array)
 			if err != nil {
 				return err
 			}

--- a/pkg/slurm/topology/tree/api.go
+++ b/pkg/slurm/topology/tree/api.go
@@ -14,8 +14,12 @@ const (
 )
 
 // SwitchRecordValidate validates the switch records from the given configuration file.
-func SwitchRecordValidate(filename string) error {
-	return switch_record_validate(filename)
+func SwitchRecordValidate(ptr_array []*slurm_conf_switches_t) error {
+	return switch_record_validate(ptr_array)
+}
+
+func ReadTopoFile(filename string) ([]*slurm_conf_switches_t, error) {
+	return _read_topo_file(filename)
 }
 
 // EvalNodesTree evaluates the nodes tree.

--- a/pkg/slurm/topology/tree/eval_nodes_tree_test.go
+++ b/pkg/slurm/topology/tree/eval_nodes_tree_test.go
@@ -11,7 +11,9 @@ import (
 )
 
 func Benchmark_eval_nodes_tree_topo3(b *testing.B) {
-	err := switch_record_validate("../../../../test/topology3.conf")
+	ptr_array, err := _read_topo_file("../../../../test/topology3.conf")
+	require.NoError(b, err)
+	err = switch_record_validate(ptr_array)
 	require.NoError(b, err)
 
 	for i := 0; i < b.N; i++ {
@@ -31,7 +33,9 @@ func Benchmark_eval_nodes_tree_topo3(b *testing.B) {
 }
 
 func Test_eval_nodes_tree_topo3(t *testing.T) {
-	err := switch_record_validate("../../../../test/topology3.conf")
+	ptr_array, err := _read_topo_file("../../../../test/topology3.conf")
+	require.NoError(t, err)
+	err = switch_record_validate(ptr_array)
 	require.NoError(t, err)
 
 	node_map := &bitstr_t{"worker001", "worker002", "worker003", "worker004", "worker005", "worker006", "worker007"}
@@ -46,7 +50,9 @@ func Test_eval_nodes_tree_topo3(t *testing.T) {
 }
 
 func Test_eval_nodes_tree_topo2(t *testing.T) {
-	err := switch_record_validate("../../../../test/topology2.conf")
+	ptr_array, err := _read_topo_file("../../../../test/topology2.conf")
+	require.NoError(t, err)
+	err = switch_record_validate(ptr_array)
 	require.NoError(t, err)
 
 	node_map := &bitstr_t{"tux0", "tux1", "tux2", "tux12", "tux13", "tux14", "tux15"}
@@ -61,7 +67,9 @@ func Test_eval_nodes_tree_topo2(t *testing.T) {
 }
 
 func Test_eval_nodes_tree_topo1(t *testing.T) {
-	err := switch_record_validate("../../../../test/topology1.conf")
+	ptr_array, err := _read_topo_file("../../../../test/topology1.conf")
+	require.NoError(t, err)
+	err = switch_record_validate(ptr_array)
 	require.NoError(t, err)
 
 	node_map := &bitstr_t{"tu-x1", "tu-x3", "tux5", "tux6", "tux7"}

--- a/pkg/slurm/topology/tree/switch_record.go
+++ b/pkg/slurm/topology/tree/switch_record.go
@@ -252,13 +252,8 @@ func _switch_record_reset() {
 	node_record_cnt = 0
 }
 
-func switch_record_validate(filename string) error {
+func switch_record_validate(ptr_array []*slurm_conf_switches_t) error {
 	_switch_record_reset()
-
-	ptr_array, err := _read_topo_file(filename)
-	if err != nil {
-		return err
-	}
 
 	switch_record_cnt = len(ptr_array)
 	if switch_record_cnt == 0 {

--- a/pkg/slurm/topology/tree/switch_record_test.go
+++ b/pkg/slurm/topology/tree/switch_record_test.go
@@ -84,7 +84,9 @@ func Test_switch_record_validate(t *testing.T) {
 		switch_record_table = make([]*switch_record_t, 0)
 		switch_record_cnt = 0
 
-		err := switch_record_validate(topo)
+		ptr_array, err := _read_topo_file(topo)
+		require.NoError(t, err)
+		err = switch_record_validate(ptr_array)
 		require.NoError(t, err)
 		require.NotEmpty(t, switch_record_table)
 		expected := 7

--- a/pkg/slurm/topology/tree/topology_tree.go
+++ b/pkg/slurm/topology/tree/topology_tree.go
@@ -14,7 +14,12 @@ func topology_p_generate_node_ranking(filename string) error {
 
 	log.Debugf("Generating node ranking %d", switch_rank)
 
-	err := switch_record_validate(filename)
+	ptr_array, err := _read_topo_file(filename)
+	if err != nil {
+		return err
+	}
+
+	err = switch_record_validate(ptr_array)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Separate ReadTopoFile from SwitchRecordValidate

This can avoid reading the file once per second when integrated into volcano, reducing IO pressure

https://github.com/yeahdongcn/volcano/blob/4564e17773a7e609536782ba411f8213c81be840/pkg/scheduler/plugins/networktopology/networktopology.go#L74
